### PR TITLE
Enable strict null checks

### DIFF
--- a/src/__tests__/plugin.spec.ts
+++ b/src/__tests__/plugin.spec.ts
@@ -50,15 +50,15 @@ function aTour(): ITour {
   };
 }
 
-function mockSettingRegistry(): Partial<ISettingRegistry> {
-  const settings: Partial<ISettingRegistry.ISettings> = {
+function mockSettingRegistry(): ISettingRegistry {
+  const settings: ISettingRegistry.ISettings = {
     composite: { tours: [(aTour() as any) as ReadonlyJSONObject] }
-  };
+  } as any;
   (settings as any)['changed'] = new Signal<any, any>(settings);
 
   return {
     load: async (): Promise<any> => settings as any
-  };
+  } as any;
 }
 
 describe(corePlugin.id, () => {
@@ -68,7 +68,7 @@ describe(corePlugin.id, () => {
       const stateDB = new StateDB();
       corePlugin.activate(app as any, stateDB);
 
-      expect(app.commands.hasCommand(CommandIDs.addTour)).toEqual(true);
+      expect(app.commands?.hasCommand(CommandIDs.addTour)).toEqual(true);
     });
   });
 
@@ -83,7 +83,7 @@ describe(corePlugin.id, () => {
         ) as ITourManager;
         expect(manager.tours.size).toEqual(0);
 
-        const tour = await app.commands.execute(CommandIDs.addTour, {
+        const tour = await app.commands?.execute(CommandIDs.addTour, {
           tour: (aTour() as any) as ReadonlyJSONObject
         });
 

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -122,7 +122,7 @@ export interface ITourContainerProps {
 export function TourContainer(props: ITourContainerProps): JSX.Element {
   return (
     <UseSignal signal={props.tourLaunched} initialArgs={[]}>
-      {(_, tours): JSX.Element =>
+      {(_, tours): React.ReactNode =>
         tours && tours.length > 0 ? <TourLauncher tours={tours} /> : null
       }
     </UseSignal>

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -76,7 +76,7 @@ function activate(
           title: manager.translator.__('Choose a tour')
         });
 
-        if (answer.button.accept) {
+        if (answer.button.accept && answer.value) {
           id = answer.value;
         } else {
           return;

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -182,7 +182,7 @@ export interface ITourHandler extends IDisposable {
    * Removes a step from the tour, no-op if the index is out of range.
    * @param index The index of the step to remove.
    */
-  removeStep(index: number): Step;
+  removeStep(index: number): Step | null;
 
   /**
    * A signal emitted if the user skips or ends the tour prematurely.

--- a/src/tour.ts
+++ b/src/tour.ts
@@ -20,8 +20,11 @@ export class TourHandler implements ITourHandler {
   ) {
     this._label = label;
     this._id = id;
-    const { styles, ...others } = options;
+    const { styles, ...others } = options ?? {};
     this._options = { ...TutorialDefaultOptions, ...others };
+    if (!this._options.styles) {
+      this._options.styles = {};
+    }
     this._options.styles.options = {
       ...(this._options.styles.options || {}),
       ...(styles?.options || {})
@@ -227,7 +230,7 @@ export class TourHandler implements ITourHandler {
    * Removes a step from the tour, no-op if the index is out of range.
    * @param index The index of the step to remove.
    */
-  removeStep(index: number): Step {
+  removeStep(index: number): Step | null {
     if (index < 0 || index >= this.steps.length) {
       return null;
     }

--- a/src/tourManager.ts
+++ b/src/tourManager.ts
@@ -297,7 +297,9 @@ export class TourManager implements ITourManager {
     // Remove tour from menu
     if (this._menu && this._menuItems.has(id)) {
       const item = this._menuItems.get(id);
-      this._menu.helpMenu.menu.removeItem(item);
+      if (item) {
+        this._menu.helpMenu.menu.removeItem(item);
+      }
       this._menuItems.delete(id);
     }
     tour.dispose();

--- a/src/userTourManager.ts
+++ b/src/userTourManager.ts
@@ -111,5 +111,5 @@ export class UserTourManager implements IUserTourManager {
   private _ready = new PromiseDelegate<void>();
   private _tourManager: ITourManager;
   private _translator: ITranslator;
-  private _userTours: ISettingRegistry.ISettings;
+  private _userTours: ISettingRegistry.ISettings | null = null;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "strict": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "target": "es2017",
     "types": ["jest"]
   },


### PR DESCRIPTION
`strictNullChecks` are often useful to catch potential issues, and when dealing with `optional` plugin dependencies.