### PR TITLE
Add missing "strings" word

### DIFF
--- a/schema/user-tours.json
+++ b/schema/user-tours.json
@@ -38,7 +38,7 @@
             "$ref": "#/definitions/Props"
           },
           "translation": {
-            "description": "Translation domain containing for this tour",
+            "description": "Translation domain containing strings for this tour",
             "type": "string"
           }
         }


### PR DESCRIPTION
Noted in Crowdin as "Translation domain containing for this tour" is not clear.