### PR TITLE
Enhance tour version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "@jupyterlab/apputils": "^4.0.0",
         "@jupyterlab/mainmenu": "^4.0.0",
         "@jupyterlab/notebook": "^4.0.0",
+        "@jupyterlab/services": "^7.0.0",
         "@jupyterlab/settingregistry": "^4.0.0",
         "@jupyterlab/statedb": "^4.0.0",
         "@jupyterlab/translation": "^4.0.0",

--- a/schema/user-tours.json
+++ b/schema/user-tours.json
@@ -46,6 +46,12 @@
             "description": "Other options for the tour",
             "$ref": "#/definitions/Props"
           },
+          "version": {
+            "type": "integer",
+            "title": "The tour version",
+            "description": "The tour version (prefer calendar versioning YYYYMMDD) to determine if an user should see it again or not.",
+            "minimum": 0
+          },
           "translation": {
             "description": "Translation domain containing strings for this tour",
             "type": "string"

--- a/src/__tests__/plugin.spec.ts
+++ b/src/__tests__/plugin.spec.ts
@@ -6,7 +6,6 @@ import {
   NotebookPanel
 } from '@jupyterlab/notebook';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
-import { StateDB } from '@jupyterlab/statedb';
 import { CommandRegistry } from '@lumino/commands';
 import { ReadonlyJSONObject } from '@lumino/coreutils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
@@ -90,8 +89,7 @@ describe(corePlugin.id, () => {
   describe('activation', () => {
     it('should create add-tour command', () => {
       const app = mockApp();
-      const stateDB = new StateDB();
-      corePlugin.activate(app as any, stateDB);
+      corePlugin.activate(app as any);
 
       expect(app.commands?.hasCommand(CommandIDs.addTour)).toEqual(true);
     });
@@ -101,8 +99,7 @@ describe(corePlugin.id, () => {
     describe(`${CommandIDs.addTour}`, () => {
       it('should add a tour command', async () => {
         const app = mockApp();
-        const stateDB = new StateDB();
-        const manager = corePlugin.activate(app as any, stateDB) as ITourManager;
+        const manager = corePlugin.activate(app as any) as ITourManager;
         expect(manager.tours.size).toEqual(0);
 
         const tour = await app.commands?.execute(CommandIDs.addTour, {
@@ -121,8 +118,7 @@ describe(userPlugin.id, () => {
   describe('activation', () => {
     it('should have userTours', async () => {
       const app = mockApp();
-      const stateDB = new StateDB();
-      const manager = corePlugin.activate(app as any, stateDB) as ITourManager;
+      const manager = corePlugin.activate(app as any) as ITourManager;
       const settings = mockSettingRegistry();
       const userManager = userPlugin.activate(
         app as any,
@@ -137,8 +133,7 @@ describe(userPlugin.id, () => {
   describe('settings', () => {
     it('should react to settings', async () => {
       const app = mockApp();
-      const stateDB = new StateDB();
-      const manager = corePlugin.activate(app as any, stateDB) as ITourManager;
+      const manager = corePlugin.activate(app as any) as ITourManager;
       const settingsRegistry = mockSettingRegistry();
       const userManager = userPlugin.activate(
         app as any,
@@ -158,8 +153,7 @@ describe(notebookPlugin.id, () => {
   describe('activation', () => {
     it('should activate', async () => {
       const app = mockApp();
-      const stateDB = new StateDB();
-      const manager = corePlugin.activate(app as any, stateDB) as ITourManager;
+      const manager = corePlugin.activate(app as any) as ITourManager;
       const nbTracker = mockNbTracker();
       const notebookTourManager = notebookPlugin.activate(
         app as any,
@@ -195,8 +189,7 @@ describe(defaultsPlugin.id, () => {
   describe('activation', () => {
     it('should activate', () => {
       const app = mockApp();
-      const stateDB = new StateDB();
-      const manager = corePlugin.activate(app as any, stateDB) as ITourManager;
+      const manager = corePlugin.activate(app as any) as ITourManager;
       defaultsPlugin.activate(app as any, manager);
       expect(manager.tours.size).toEqual(DEFAULT_TOURS_SIZE);
     });

--- a/src/defaults.tsx
+++ b/src/defaults.tsx
@@ -23,13 +23,13 @@ namespace DefaultTours {
     ): void {
       const trans = manager.translator;
 
-      const welcomeTour = manager.createTour(
-        WELCOME_ID,
-        trans.__('Welcome Tour'),
-        true,
-        undefined,
-        defaultTourIcon
-      );
+      const welcomeTour = manager.createTour({
+        id: WELCOME_ID,
+        label: trans.__('Welcome Tour'),
+        hasHelpEntry: true,
+        icon: defaultTourIcon,
+        version: 20231107
+      });
 
       welcomeTour.options = {
         ...welcomeTour.options,
@@ -292,13 +292,13 @@ namespace DefaultTours {
       appName = 'JupyterLab'
     ): void {
       const trans = manager.translator;
-      const notebookTour = manager.createTour(
-        NOTEBOOK_ID,
-        trans.__('Notebook Tour'),
-        true,
-        undefined,
-        defaultNotebookTourIcon
-      );
+      const notebookTour = manager.createTour({
+        id: NOTEBOOK_ID,
+        label: trans.__('Notebook Tour'),
+        hasHelpEntry: true,
+        icon: defaultNotebookTourIcon,
+        version: 20231107
+      });
 
       notebookTour.options = {
         ...notebookTour.options,
@@ -541,11 +541,12 @@ namespace DefaultTours {
     ): void {
       const trans = manager.translator;
 
-      const welcomeTour = manager.createTour(
-        WELCOME_ID,
-        trans.__('Welcome Tour'),
-        true
-      );
+      const welcomeTour = manager.createTour({
+        id: WELCOME_ID,
+        label: trans.__('Welcome Tour'),
+        hasHelpEntry: true,
+        version: 20231107
+      });
 
       welcomeTour.options = {
         ...welcomeTour.options,

--- a/src/notebookButton.tsx
+++ b/src/notebookButton.tsx
@@ -44,7 +44,9 @@ export class TourButton extends ReactWidget {
     const errors = this._manager.getNotebookValidationErrors(this._notebook);
 
     if (errors.length) {
-      title = `${this.translator.__('Tour Validation Errors')}: ${errors.length}`;
+      title = `${this.translator.__('Tour Validation Errors')}: ${
+        errors.length
+      }`;
       icon = errorTourIcon;
     }
 
@@ -56,7 +58,7 @@ export class TourButton extends ReactWidget {
         title={title}
         value=""
       >
-        <option value=""></option>
+        <option style={{ display: 'none' }} value=""></option>
         {errors.length ? (
           <option>
             {trans.__('Tour metadata is not valid: see the browser console!')}
@@ -67,7 +69,9 @@ export class TourButton extends ReactWidget {
         {tourIds.length ? (
           <option value="ALL">{trans.__('Run all Tours')}</option>
         ) : (
-          <optgroup label={trans.__('No Tours found in this Notebook')}></optgroup>
+          <optgroup
+            label={trans.__('No Tours found in this Notebook')}
+          ></optgroup>
         )}
         {tourIds.length ? (
           <optgroup label={trans.__('Notebook Tours')}>
@@ -83,7 +87,9 @@ export class TourButton extends ReactWidget {
   /**
    * Handle `change` events for the HTMLSelect component.
    */
-  handleChange = async (event: React.ChangeEvent<HTMLSelectElement>): Promise<void> => {
+  handleChange = async (
+    event: React.ChangeEvent<HTMLSelectElement>
+  ): Promise<void> => {
     const { value } = event.target;
     switch (value) {
       case '-':

--- a/src/notebookButton.tsx
+++ b/src/notebookButton.tsx
@@ -44,9 +44,7 @@ export class TourButton extends ReactWidget {
     const errors = this._manager.getNotebookValidationErrors(this._notebook);
 
     if (errors.length) {
-      title = `${this.translator.__('Tour Validation Errors')}: ${
-        errors.length
-      }`;
+      title = `${this.translator.__('Tour Validation Errors')}: ${errors.length}`;
       icon = errorTourIcon;
     }
 
@@ -69,9 +67,7 @@ export class TourButton extends ReactWidget {
         {tourIds.length ? (
           <option value="ALL">{trans.__('Run all Tours')}</option>
         ) : (
-          <optgroup
-            label={trans.__('No Tours found in this Notebook')}
-          ></optgroup>
+          <optgroup label={trans.__('No Tours found in this Notebook')}></optgroup>
         )}
         {tourIds.length ? (
           <optgroup label={trans.__('Notebook Tours')}>
@@ -87,9 +83,7 @@ export class TourButton extends ReactWidget {
   /**
    * Handle `change` events for the HTMLSelect component.
    */
-  handleChange = async (
-    event: React.ChangeEvent<HTMLSelectElement>
-  ): Promise<void> => {
+  handleChange = async (event: React.ChangeEvent<HTMLSelectElement>): Promise<void> => {
     const { value } = event.target;
     switch (value) {
       case '-':

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -62,12 +62,14 @@ function activate(
   const restoreState = new PromiseDelegate<ITourState[]>();
   const configReady = ConfigSection.create({
     name: CONFIG_SECTION_NAME
+  }).catch(error => {
+    console.error('Failed to fetch state for jupyterlab-tour.', error);
   });
   const tracker: ITourTracker = Object.freeze({
     restored: restoreState.promise,
     save: async (state: ITourState[]) => {
       await restoreState.promise;
-      (await configReady).update(state as any);
+      (await configReady)?.update({ state } as any);
     }
   });
 
@@ -80,7 +82,7 @@ function activate(
     configReady
   ])
     .then(async ([_, config]) => {
-      restoreState.resolve(config.data as any);
+      restoreState.resolve((config?.data['state'] ?? []) as any);
     })
     .catch(error => {
       console.error('Failed to load tour states.', error);

--- a/src/tour.ts
+++ b/src/tour.ts
@@ -19,11 +19,13 @@ export class TourHandler implements ITourHandler {
     id: string,
     label: string,
     options?: Omit<JoyrideProps, 'steps'>,
-    icon: LabIcon | null = null
+    icon: LabIcon | null = null,
+    version: number = -1
   ) {
     this._label = label;
     this._id = id;
     this._icon = icon || null;
+    this._version = version;
     const { styles, ...others } = options ?? {};
     this._options = { ...TutorialDefaultOptions, ...others };
     if (!this._options.styles) {
@@ -127,6 +129,18 @@ export class TourHandler implements ITourHandler {
 
   set steps(steps: Step[]) {
     this._steps = steps;
+  }
+
+  /**
+   * Tour version
+   *
+   * If a newer tour is available, it will be proposed to the user.
+   *
+   * #### Notes
+   * Prefer calendar versioning (YYYYMMDD)
+   */
+  get version(): number {
+    return this._version;
   }
 
   /**
@@ -266,4 +280,5 @@ export class TourHandler implements ITourHandler {
   private _previousStepIndex = -1;
   private _steps: Step[] = new Array<Step>();
   private _icon: LabIcon | null;
+  private _version: number;
 }

--- a/src/tourManager.ts
+++ b/src/tourManager.ts
@@ -1,41 +1,35 @@
 import { ISignal, Signal } from '@lumino/signaling';
 import { Notification } from '@jupyterlab/apputils';
-import { MainMenu } from '@jupyterlab/mainmenu';
-import { IStateDB } from '@jupyterlab/statedb';
-import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
-import { IDisposableMenuItem, LabIcon } from '@jupyterlab/ui-components';
-import { Locale, Props as JoyrideProps } from 'react-joyride';
+import {
+  ITranslator,
+  TranslationBundle,
+  nullTranslator
+} from '@jupyterlab/translation';
+import { IDisposableMenuItem, LabIcon, RankedMenu } from '@jupyterlab/ui-components';
+import { Locale } from 'react-joyride';
 
 import { CommandIDs } from './constants';
-import { ITour, ITourHandler, ITourManager, NS, VERSION } from './tokens';
+import {
+  ITour,
+  ITourHandler,
+  ITourManager,
+  ITourManagerOptions,
+  ITourState,
+  ITourTracker
+} from './tokens';
 import { TourHandler } from './tour';
-
-const STATE_ID = `${NS}:state`;
-
-/**
- * Manager state saved in the state database
- */
-interface IManagerState {
-  /**
-   * Set of seen tour IDs
-   */
-  toursDone: Set<string>;
-  /**
-   * Tour extension version
-   */
-  version: string;
-}
+import { PromiseDelegate } from '@lumino/coreutils';
 
 /**
  * The TourManager is needed to manage creation, removal and launching of Tutorials
  */
 export class TourManager implements ITourManager {
-  constructor(stateDB: IStateDB, translator: ITranslator, mainMenu?: MainMenu) {
-    this._stateDB = stateDB;
-    this._menu = mainMenu;
+  constructor(options: ITourManagerOptions = {}) {
+    this._menu = options.helpMenu;
     this._tours = new Map<string, TourHandler>();
-    this._trans = translator.load('jupyterlab_tour');
-    this._translator = translator;
+    this._tracker = options.tracker ?? null;
+    this._translator = options.translator ?? nullTranslator;
+    this._trans = this._translator.load('jupyterlab_tour');
 
     this._locale = {
       back: this._trans.__('Back'),
@@ -46,20 +40,19 @@ export class TourManager implements ITourManager {
       skip: this._trans.__('Skip')
     };
 
-    this._stateDB.fetch(STATE_ID).then(value => {
-      if (value) {
-        const savedState = value as any as IManagerState;
-        if (savedState.version !== VERSION) {
-          this._state.toursDone = new Set<string>();
-          this._stateDB.save(STATE_ID, {
-            version: VERSION,
-            toursDone: []
-          });
-        } else {
-          this._state.toursDone = new Set<string>([...savedState.toursDone]);
-        }
-      }
-    });
+    const initialize = new PromiseDelegate<void>();
+    this._ready = initialize.promise;
+    if (this._tracker) {
+      this._tracker.restored
+        .then(state => {
+          this._state = state;
+        })
+        .catch(error => {
+          initialize.reject(error);
+        });
+    } else {
+      initialize.resolve();
+    }
   }
 
   /**
@@ -75,6 +68,13 @@ export class TourManager implements ITourManager {
    */
   get isDisposed(): boolean {
     return this._isDisposed;
+  }
+
+  /**
+   * Promise that resolves when the manager state is restored.
+   */
+  get ready(): Promise<void> {
+    return this._ready;
   }
 
   /**
@@ -115,13 +115,14 @@ export class TourManager implements ITourManager {
         trans = this._translator.load(tour.translation);
       }
 
-      const handler = this.createTour(
-        tour.id,
-        trans.__(tour.label),
-        tour.hasHelpEntry === false ? false : true,
-        tour.options,
-        tour.icon ? LabIcon.resolve({ icon: tour.icon }) : null
-      );
+      const handler = this.createTour({
+        id: tour.id,
+        label: trans.__(tour.label),
+        hasHelpEntry: tour.hasHelpEntry === false ? false : true,
+        options: tour.options,
+        icon: tour.icon ? LabIcon.resolve({ icon: tour.icon }) : undefined,
+        version: tour.version
+      });
 
       tour.steps.forEach(step => {
         const translatedStep = { ...step };
@@ -157,12 +158,14 @@ export class TourManager implements ITourManager {
    * The tour label will not be translated.
    */
   createTour = (
-    id: string,
-    label: string,
-    addToHelpMenu = true,
-    options: Omit<JoyrideProps, 'steps'> = {},
-    icon: LabIcon | null = null
+    args: Omit<ITour, 'icon' | 'steps'> & { icon?: LabIcon }
   ): ITourHandler => {
+    const { id, label } = args;
+    const addToHelpMenu = args.hasHelpEntry ?? true;
+    const options = args.options ?? {};
+    const icon = args.icon ?? null;
+    const version = args.version ?? 0;
+
     if (this._tours.has(id)) {
       throw new Error(
         this._trans.__(
@@ -178,7 +181,7 @@ export class TourManager implements ITourManager {
     }
 
     // Create tour and add it to help menu if needed
-    const newTutorial: TourHandler = new TourHandler(id, label, options, icon);
+    const newTutorial: TourHandler = new TourHandler(id, label, options, icon, version);
     if (this._menu && addToHelpMenu) {
       const options = {
         args: {
@@ -186,18 +189,12 @@ export class TourManager implements ITourManager {
         },
         command: CommandIDs.launch
       };
-      const menuItem = this._menu.helpMenu.addItem(options);
+      const menuItem = this._menu.addItem(options);
       this._menuItems.set(newTutorial.id, menuItem);
     }
 
     // Add tour to current set
     this._tours.set(id, newTutorial);
-
-    const done = (tour: TourHandler): void => {
-      this._rememberDoneTour(tour.id);
-    };
-    newTutorial.skipped.connect(done);
-    newTutorial.finished.connect(done);
 
     return newTutorial;
   };
@@ -237,7 +234,11 @@ export class TourManager implements ITourManager {
     ) as TourHandler[];
 
     if (!force) {
-      tourList = tourList.filter(tour => !this._state.toursDone.has(tour.id));
+      tourList = tourList.filter(tour =>
+        tour.version >= 0
+          ? !this._state.includes({ id: tour.id, version: tour.version })
+          : !this._state.map(s => s.id).includes(tour.id)
+      );
     }
 
     const startTours = (): void => {
@@ -320,19 +321,24 @@ export class TourManager implements ITourManager {
   }
 
   private _forgetDoneTour = (id: string): void => {
-    this._state.toursDone.delete(id);
-    this._stateDB.save(STATE_ID, {
-      toursDone: [...this._state.toursDone],
-      version: VERSION
-    });
+    const stateIdx = this._state.findIndex(t => t.id === id);
+    if (stateIdx >= 0) {
+      this._state = this._state.splice(stateIdx, 1);
+      this._tracker?.save(this._state);
+    }
   };
 
   private _rememberDoneTour = (id: string): void => {
-    this._state.toursDone.add(id);
-    this._stateDB.save(STATE_ID, {
-      toursDone: [...this._state.toursDone],
-      version: VERSION
-    });
+    const stateIdx = this._state.findIndex(t => t.id === id);
+    if (stateIdx >= 0) {
+      this._state[stateIdx].version = this.tours.get(id)!.version ?? -1;
+    } else {
+      this._state.push({
+        id,
+        version: this.tours.get(id)!.version ?? -1
+      });
+    }
+    this._tracker?.save(this._state);
   };
 
   /**
@@ -359,13 +365,11 @@ export class TourManager implements ITourManager {
   private _activeTours: TourHandler[] = new Array<TourHandler>();
   private _isDisposed = false;
   private _locale: Locale;
-  private _menu: MainMenu | undefined;
+  private _menu: RankedMenu | undefined;
   private _menuItems: Map<string, IDisposableMenuItem> = new Map();
-  private _state: IManagerState = {
-    toursDone: new Set<string>(),
-    version: VERSION
-  };
-  private _stateDB: IStateDB;
+  private _ready: Promise<void>;
+  private _state: ITourState[] = [];
+  private _tracker: ITourTracker | null;
   private _trans: TranslationBundle;
   private _translator: ITranslator;
   private _tours: Map<string, TourHandler>;

--- a/src/userTourManager.ts
+++ b/src/userTourManager.ts
@@ -11,9 +11,8 @@ export class UserTourManager implements IUserTourManager {
   constructor(options: IUserTourManager.IOptions) {
     this._tourManager = options.tourManager;
 
-    options
-      .getSettings()
-      .then(userTours => {
+    Promise.all([options.getSettings(), this._tourManager.ready])
+      .then(([userTours]) => {
         this._userTours = userTours;
         this._userTours.changed.connect(this._userToursChanged, this);
         this._userToursChanged();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2296,6 +2296,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/coreutils@npm:^6.0.8":
+  version: 6.0.8
+  resolution: "@jupyterlab/coreutils@npm:6.0.8"
+  dependencies:
+    "@lumino/coreutils": ^2.1.2
+    "@lumino/disposable": ^2.1.2
+    "@lumino/signaling": ^2.1.2
+    minimist: ~1.2.0
+    path-browserify: ^1.0.0
+    url-parse: ~1.5.4
+  checksum: b56e3b95c0ce52745b79549ef5b18a27e620086b87cf997b3a743b59d18dc529e403c812751b7e294a4abc60ac957381301e14327e1a4b9c1afb232f181f3a4d
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/docmanager@npm:^4.0.5":
   version: 4.0.5
   resolution: "@jupyterlab/docmanager@npm:4.0.5"
@@ -2435,6 +2449,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/nbformat@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "@jupyterlab/nbformat@npm:4.0.8"
+  dependencies:
+    "@lumino/coreutils": ^2.1.2
+  checksum: 2d8255ac7c7c20dbfa8497ce4d8d2f5840568adefb2feaec8eb8ddbb4892f50706ce60e8c4719113485c5523f720802f7e4e7b63ed43fac90f870ff1134bed7a
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/notebook@npm:^4.0.0, @jupyterlab/notebook@npm:^4.0.5":
   version: 4.0.5
   resolution: "@jupyterlab/notebook@npm:4.0.5"
@@ -2536,6 +2559,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/services@npm:^7.0.0":
+  version: 7.0.8
+  resolution: "@jupyterlab/services@npm:7.0.8"
+  dependencies:
+    "@jupyter/ydoc": ^1.0.2
+    "@jupyterlab/coreutils": ^6.0.8
+    "@jupyterlab/nbformat": ^4.0.8
+    "@jupyterlab/settingregistry": ^4.0.8
+    "@jupyterlab/statedb": ^4.0.8
+    "@lumino/coreutils": ^2.1.2
+    "@lumino/disposable": ^2.1.2
+    "@lumino/polling": ^2.1.2
+    "@lumino/properties": ^2.0.1
+    "@lumino/signaling": ^2.1.2
+    ws: ^8.11.0
+  checksum: b0112854d3014eff9d9855a6840d1efd0d866d4c011e7a9c4c1c5fba404dd13107b62de6ce845902d12cc6404aafdfee95127a2af43560ade53a00fc7b73378a
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/services@npm:^7.0.5":
   version: 7.0.5
   resolution: "@jupyterlab/services@npm:7.0.5"
@@ -2574,6 +2616,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/settingregistry@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "@jupyterlab/settingregistry@npm:4.0.8"
+  dependencies:
+    "@jupyterlab/nbformat": ^4.0.8
+    "@jupyterlab/statedb": ^4.0.8
+    "@lumino/commands": ^2.1.3
+    "@lumino/coreutils": ^2.1.2
+    "@lumino/disposable": ^2.1.2
+    "@lumino/signaling": ^2.1.2
+    "@rjsf/utils": ^5.1.0
+    ajv: ^8.12.0
+    json5: ^2.2.3
+  peerDependencies:
+    react: ">=16"
+  checksum: e9661539357edae60e4b300dff68b369e95e96acb343aeb25e23bdbcd6964c59dd40118ce3a856afaf969833958f3872c480e75cc488a5e882546cb88587c461
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/statedb@npm:^4.0.0, @jupyterlab/statedb@npm:^4.0.5":
   version: 4.0.5
   resolution: "@jupyterlab/statedb@npm:4.0.5"
@@ -2584,6 +2645,19 @@ __metadata:
     "@lumino/properties": ^2.0.1
     "@lumino/signaling": ^2.1.2
   checksum: 8e01de74a2168d19124773fa2b72329cfb43601c702127845a4172e87ee67b1304d34f53f65a6db214d832bd8c244c333936a22e08bbf1ea02e458e245140f62
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/statedb@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "@jupyterlab/statedb@npm:4.0.8"
+  dependencies:
+    "@lumino/commands": ^2.1.3
+    "@lumino/coreutils": ^2.1.2
+    "@lumino/disposable": ^2.1.2
+    "@lumino/properties": ^2.0.1
+    "@lumino/signaling": ^2.1.2
+  checksum: bfd016e91158daf47e07e760126c0c2c3f6d01ecc8e9cad3e17241e5873decbc5fdfce82bf039fa83633b8760245af8003008f38272dafba56b73ac24768a99f
   languageName: node
   linkType: hard
 
@@ -7708,6 +7782,7 @@ __metadata:
     "@jupyterlab/builder": ^4.0.0
     "@jupyterlab/mainmenu": ^4.0.0
     "@jupyterlab/notebook": ^4.0.0
+    "@jupyterlab/services": ^7.0.0
     "@jupyterlab/settingregistry": ^4.0.0
     "@jupyterlab/statedb": ^4.0.0
     "@jupyterlab/testutils": ^4.0.0


### PR DESCRIPTION
What changes:
- Version is now per tour basis
- Tour state is stored using the jupyter-server config REST API to be independent of the lab workspaces.
- Change a couple of argument API to be object based rather than list based.
